### PR TITLE
Fix broken map.

### DIFF
--- a/map_controller.js
+++ b/map_controller.js
@@ -34,6 +34,9 @@ function onSpreadsheetData(json) {
         fields.forEach(function (name) {
             var fieldName = name.toLowerCase();
             var value = row["gsx$" + fieldName].$t;
+            if (row["gsx$" + fieldName] === undefined) {
+                return;
+            }
             if (sameOrg && value === "")
               value = lastRow[name];
             newRow[name] = value;


### PR DESCRIPTION
If an entry gets added to the google doc and is missing values in the fields that get mapped in the google map object, then all the map fails. Let's gracefully handle this so the map does not die just cause a field is missing. 